### PR TITLE
Fix type definitions of array parameter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ function checkArgument(value: unknown, name: string) {
 }
 
 export default async function<T>(
-  array: T[],
+  array: readonly T[],
   callback: (value: T, index: number) => Promise<boolean>,
   progressCb?: (value: T, index: number) => void,
 ): Promise<T[]> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "removeComments": true,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "target": "ES5",
+    "target": "ES2015",
     "declaration": true,
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Since the array is not manipulated, it must not be writable. By also allowing for read-only arrays, clients do not need to do redundant casts when passing non-standard arrays to this module.